### PR TITLE
[ONME-2461] Correcting Dependencies

### DIFF
--- a/module.json
+++ b/module.json
@@ -10,8 +10,8 @@
   "license": "Proprietary, all rights reserved.",
   "dependencies": {
     "nanostack-libservice": "^3.0.0",
-    "sal-stack-nanostack": "^3.0.0",
-    "mbed-drivers": "*"
+    "sal-stack-nanostack": "ARMmbed/sal-stack-nanostack-private#v3.0.6",
+    "mbed-drivers": "^1.0.0"
   },
   "targetDependencies": {}
 }


### PR DESCRIPTION
Nanostack dependency is changed to 3.0.6 which does better memory management
