### PR TITLE
Update mbed-drivers dependencies

### DIFF
--- a/module.json
+++ b/module.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "nanostack-libservice": "^3.0.0",
     "sal-stack-nanostack": "^3.0.0",
-    "mbed-drivers": "*"
+    "mbed-drivers": "^1.0.0"
   },
   "targetDependencies": {}
 }


### PR DESCRIPTION
"*" should only be used for early development and believe mbed-drivers v1 is stable.
@bangaragirinxp
